### PR TITLE
Add text-based Minecraft-inspired sandbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,51 @@
+# Mini Minecraft Sandbox
+
+This project is a small text-based sandbox that captures a slice of the Minecraft experience. It generates a miniature voxel world, lets you explore it with simple commands, and supports harvesting, placing, and crafting a handful of block types.
+
+## Features
+
+* Procedural overworld generation with grasslands, sandy beaches, water, and the occasional tree.
+* A `Player` avatar who can walk across the landscape, climb, and inspect nearby blocks.
+* Inventory management with harvesting and placing of blocks.
+* Basic crafting: turn gathered logs into stacks of wooden planks.
+* ASCII map rendering that shows the surrounding area from a top-down perspective.
+
+## Getting Started
+
+The project has no external dependencies beyond the Python standard library.
+
+```bash
+python main.py
+```
+
+Type `help` inside the game for a full list of commands. Example session:
+
+```
+Welcome to the miniature Minecraft sandbox! Type 'help' for instructions.
+> look
+You are standing above grass.
+There is air at head height.
+Beneath you lies dirt.
+
+▒▒▒▒▒▒▒
+▒▒▒▒▒▒▒
+▒▒▒▒▒▒▒
+▒▒▒▒▒▒▒
+▒▒▒▒▒▒▒
+▒▒▒▒▒▒▒
+▒▒▒▒▒▒▒
+> harvest up
+You gather one Oak Leaves.
+> craft planks
+You do not have the resources to craft that.
+> quit
+Thanks for playing!
+```
+
+## Running Tests
+
+```
+pytest
+```
+
+The test suite checks the most important mechanics, such as terrain generation, inventory management, and crafting.

--- a/main.py
+++ b/main.py
@@ -1,0 +1,13 @@
+"""Entry point for the miniature Minecraft sandbox."""
+from __future__ import annotations
+
+from minecraft.game import Game
+
+
+def main() -> None:
+    game = Game()
+    game.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/minecraft/__init__.py
+++ b/minecraft/__init__.py
@@ -1,0 +1,8 @@
+"""A tiny text-based Minecraft-inspired sandbox."""
+
+from .blocks import Block, BLOCKS, get_block
+from .world import World
+from .player import Player
+from .game import Game
+
+__all__ = ["Block", "BLOCKS", "get_block", "World", "Player", "Game"]

--- a/minecraft/blocks.py
+++ b/minecraft/blocks.py
@@ -1,0 +1,141 @@
+"""Definitions for the different block types used in the sandbox."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict
+
+
+@dataclass(frozen=True)
+class Block:
+    """Representation of a block type.
+
+    Parameters
+    ----------
+    id:
+        The identifier used internally.
+    name:
+        Human friendly name of the block.
+    hardness:
+        Rough approximation of how hard the block is to break.
+    solid:
+        Whether the block blocks movement.
+    description:
+        Short blurb describing the block.
+    """
+
+    id: str
+    name: str
+    hardness: float
+    solid: bool = True
+    description: str = ""
+
+    def __str__(self) -> str:  # pragma: no cover - trivial
+        return self.name
+
+
+BLOCKS: Dict[str, Block] = {
+    "air": Block("air", "Air", hardness=0.0, solid=False, description="Empty space."),
+    "grass": Block(
+        "grass",
+        "Grass",
+        hardness=0.6,
+        description="Soft topsoil covered with fresh grass.",
+    ),
+    "dirt": Block(
+        "dirt",
+        "Dirt",
+        hardness=0.5,
+        description="Soil that is easy to dig through.",
+    ),
+    "stone": Block(
+        "stone",
+        "Stone",
+        hardness=1.5,
+        description="Solid rock deep below the surface.",
+    ),
+    "water": Block(
+        "water",
+        "Water",
+        hardness=100.0,
+        solid=False,
+        description="A splash of refreshing water.",
+    ),
+    "sand": Block(
+        "sand",
+        "Sand",
+        hardness=0.4,
+        description="Grains of crushed stone gathered near the shore.",
+    ),
+    "log": Block(
+        "log",
+        "Oak Log",
+        hardness=1.0,
+        description="A sturdy log that can be turned into planks.",
+    ),
+    "leaves": Block(
+        "leaves",
+        "Oak Leaves",
+        hardness=0.2,
+        solid=False,
+        description="Foliage rustling in the wind.",
+    ),
+    "planks": Block(
+        "planks",
+        "Oak Planks",
+        hardness=1.2,
+        description="Refined wood boards perfect for building shelters.",
+    ),
+}
+
+
+def get_block(block_id: str) -> Block:
+    """Return the :class:`Block` instance for ``block_id``.
+
+    Parameters
+    ----------
+    block_id:
+        Identifier of the block to fetch. The lookup is case-insensitive.
+
+    Raises
+    ------
+    KeyError
+        If the requested block identifier is not known.
+    """
+
+    normalized = block_id.lower()
+    if normalized not in BLOCKS:
+        raise KeyError(f"Unknown block type: {block_id!r}")
+    return BLOCKS[normalized]
+
+
+CRAFTING_RECIPES = {
+    "planks": {"log": 1},
+}
+
+
+def can_craft(block_id: str, inventory: Dict[str, int]) -> bool:
+    """Return whether the ``inventory`` contains enough resources to craft ``block_id``."""
+
+    recipe = CRAFTING_RECIPES.get(block_id)
+    if recipe is None:
+        return False
+    return all(inventory.get(item, 0) >= count for item, count in recipe.items())
+
+
+def craft(block_id: str, inventory: Dict[str, int]) -> bool:
+    """Attempt to craft ``block_id`` using the provided ``inventory``.
+
+    The function mutates ``inventory`` in place and returns ``True`` on success.
+    """
+
+    recipe = CRAFTING_RECIPES.get(block_id)
+    if recipe is None:
+        return False
+    if not can_craft(block_id, inventory):
+        return False
+    for item, count in recipe.items():
+        inventory[item] -= count
+        if inventory[item] <= 0:
+            inventory.pop(item)
+    inventory[block_id] = inventory.get(block_id, 0) + 4 if block_id == "planks" else inventory.get(block_id, 0) + 1
+    return True

--- a/minecraft/game.py
+++ b/minecraft/game.py
@@ -1,0 +1,153 @@
+"""Text adventure style interface for the sandbox."""
+from __future__ import annotations
+
+from typing import List, Optional
+
+from .blocks import BLOCKS
+from .player import Player
+from .world import World
+
+
+class Game:
+    """High level façade exposing the sandbox via textual commands."""
+
+    def __init__(
+        self,
+        *,
+        width: int = 32,
+        depth: int = 32,
+        height: int = 32,
+        seed: Optional[int] = None,
+    ) -> None:
+        self.world = World(width=width, depth=depth, height=height, seed=seed)
+        self.player = Player(self.world)
+
+    # ------------------------------------------------------------------
+    # Command handling
+
+    def execute(self, command: str) -> str:
+        """Execute ``command`` and return the response string."""
+
+        command = command.strip()
+        if not command:
+            return ""
+        parts = command.split()
+        action = parts[0].lower()
+        args = parts[1:]
+
+        if action in {"quit", "exit"}:
+            return "Thanks for playing!"
+        if action in {"help", "?"}:
+            return self._help_text()
+        if action in {"look", "see"}:
+            return self._look()
+        if action in {"map"}:
+            return self._map(args)
+        if action in {"move", "walk", "go"}:
+            return self._move(args)
+        if action in {"harvest", "mine", "break", "dig"}:
+            return self._harvest(args)
+        if action in {"place", "build"}:
+            return self._place(args)
+        if action in {"inventory", "inv"}:
+            return self.player.inventory_summary()
+        if action == "craft":
+            return self._craft(args)
+        if action in {"where", "pos"}:
+            x, y, z = self.player.position
+            return f"You are at ({x}, {y}, {z})."
+        return f"I do not understand '{command}'. Type 'help' for options."
+
+    def _help_text(self) -> str:
+        return (
+            "Commands:\n"
+            "  look                - describe nearby blocks\n"
+            "  map [radius]        - show a top-down map around you\n"
+            "  move <dir>          - walk north, south, east or west\n"
+            "  harvest [dir]       - break the block in a direction\n"
+            "  place <block> [dir] - place a block if you have one\n"
+            "  craft <block>       - craft items if you have the resources\n"
+            "  inventory           - list carried blocks\n"
+            "  where               - show your current position\n"
+            "  quit                - exit the game"
+        )
+
+    def _look(self) -> str:
+        description = self.player.describe_surroundings()
+        map_view = self.world.top_view(self.player.position, radius=4)
+        return f"{description}\n\n{map_view}"
+
+    def _map(self, args: List[str]) -> str:
+        radius = 6
+        if args:
+            try:
+                radius = max(1, min(10, int(args[0])))
+            except ValueError:
+                return "Map radius must be a number."
+        return self.world.top_view(self.player.position, radius=radius)
+
+    def _move(self, args: List[str]) -> str:
+        if not args:
+            return "Move where? Try north, south, east or west."
+        direction = args[0].lower()
+        try:
+            moved = self.player.move(direction)
+        except ValueError as exc:  # Unknown direction
+            return str(exc)
+        if moved:
+            x, y, z = self.player.position
+            return f"You move {direction} to ({x}, {y}, {z})."
+        return "You cannot move in that direction."
+
+    def _harvest(self, args: List[str]) -> str:
+        direction = args[0].lower() if args else None
+        try:
+            block_id = self.player.harvest(direction)
+        except ValueError as exc:
+            return str(exc)
+        if block_id is None:
+            return "There is nothing to harvest there."
+        block_name = BLOCKS[block_id].name
+        return f"You gather one {block_name}."
+
+    def _place(self, args: List[str]) -> str:
+        if not args:
+            return "Place what?"
+        block_id = args[0].lower()
+        direction = args[1].lower() if len(args) > 1 else None
+        if block_id not in BLOCKS:
+            return f"Unknown block type '{block_id}'."
+        try:
+            placed = self.player.place(block_id, direction)
+        except ValueError as exc:
+            return str(exc)
+        if placed:
+            return f"You place a {BLOCKS[block_id].name}."
+        return "You cannot place a block there."
+
+    def _craft(self, args: List[str]) -> str:
+        if not args:
+            return "Craft what?"
+        block_id = args[0].lower()
+        if block_id not in BLOCKS:
+            return f"Unknown block type '{block_id}'."
+        crafted = self.player.craft(block_id)
+        if crafted:
+            return f"You craft {BLOCKS[block_id].name}."
+        return "You do not have the resources to craft that."
+
+    # ------------------------------------------------------------------
+    # Interactive loop
+
+    def run(self) -> None:  # pragma: no cover - the interactive loop is hard to test.
+        print("Welcome to the miniature Minecraft sandbox! Type 'help' for instructions.")
+        while True:
+            try:
+                command = input("> ")
+            except EOFError:
+                print()
+                break
+            response = self.execute(command)
+            print(response)
+            if command.strip().lower() in {"quit", "exit"}:
+                break

--- a/minecraft/player.py
+++ b/minecraft/player.py
@@ -1,0 +1,137 @@
+"""Player state and interaction helpers."""
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass, field
+from typing import Dict, Optional, Tuple
+
+from . import blocks
+from .world import Coordinate, World
+
+Direction = Tuple[int, int, int]
+
+
+DIRECTIONS: Dict[str, Direction] = {
+    "north": (0, 0, -1),
+    "south": (0, 0, 1),
+    "east": (1, 0, 0),
+    "west": (-1, 0, 0),
+    "up": (0, 1, 0),
+    "down": (0, -1, 0),
+}
+
+
+@dataclass
+class Player:
+    """Simple player representation."""
+
+    world: World
+    position: Coordinate = field(init=False)
+    inventory: Counter = field(default_factory=Counter)
+
+    def __post_init__(self) -> None:
+        spawn = self.world.spawn_position()
+        self.position = (spawn[0], spawn[1] + 1, spawn[2])
+        # Provide a starting kit for building shelters.
+        self.inventory.update({"planks": 8})
+
+    # ------------------------------------------------------------------
+    # Movement
+
+    def move(self, direction: str) -> bool:
+        """Move the player in ``direction`` if possible."""
+
+        if direction not in DIRECTIONS:
+            raise ValueError(f"Unknown direction: {direction}")
+
+        dx, dy, dz = DIRECTIONS[direction]
+        x, y, z = self.position
+        new_position = (x + dx, y + dy, z + dz)
+
+        if direction in {"up", "down"}:
+            target_block = self.world.get_block(new_position)
+            if target_block.id == "air" or target_block.id == "water":
+                self.position = new_position
+                return True
+            return False
+
+        # Horizontal movement steps to the surface of the destination column.
+        dest_x = new_position[0]
+        dest_z = new_position[2]
+        if not (0 <= dest_x < self.world.bounds.width and 0 <= dest_z < self.world.bounds.depth):
+            return False
+        dest_y = self.world.column_height(dest_x, dest_z) + 1
+        if dest_y >= self.world.bounds.height:
+            return False
+        self.position = (dest_x, dest_y, dest_z)
+        return True
+
+    # ------------------------------------------------------------------
+    # Block interaction helpers
+
+    def _target_from_direction(self, direction: Optional[str]) -> Coordinate:
+        x, y, z = self.position
+        if direction is None:
+            direction = "up"
+        if direction not in DIRECTIONS:
+            raise ValueError(f"Unknown direction: {direction}")
+        dx, dy, dz = DIRECTIONS[direction]
+        return (x + dx, y + dy, z + dz)
+
+    def harvest(self, direction: Optional[str] = None) -> Optional[str]:
+        """Break the block in ``direction`` and add it to the inventory."""
+
+        target = self._target_from_direction(direction)
+        block = self.world.get_block(target)
+        if block.id in {"air", "water"}:
+            return None
+        removed = self.world.remove_block(target)
+        if removed is None:
+            return None
+        self.inventory[removed.id] += 1
+        return removed.id
+
+    def place(self, block_id: str, direction: Optional[str] = None) -> bool:
+        """Place ``block_id`` in ``direction`` if the space is empty."""
+
+        target = self._target_from_direction(direction)
+        block_id = block_id.lower()
+        if self.inventory.get(block_id, 0) <= 0:
+            return False
+        existing = self.world.get_block(target)
+        if existing.id != "air" and existing.id != "water":
+            return False
+        placed = self.world.set_block(target, block_id)
+        if placed:
+            self.inventory[block_id] -= 1
+            if self.inventory[block_id] <= 0:
+                del self.inventory[block_id]
+        return placed
+
+    def craft(self, block_id: str) -> bool:
+        """Attempt to craft ``block_id`` using available resources."""
+
+        return blocks.craft(block_id, self.inventory)
+
+    # ------------------------------------------------------------------
+    # Presentation helpers
+
+    def describe_surroundings(self) -> str:
+        """Return a textual description of nearby blocks."""
+
+        x, y, z = self.position
+        head_block = self.world.get_block((x, y, z))
+        ground_block = self.world.get_block((x, y - 1, z))
+        below_block = self.world.get_block((x, y - 2, z)) if y - 2 >= 0 else blocks.BLOCKS["stone"]
+        descriptions = [
+            f"You are standing above {ground_block.name.lower()}.",
+            f"There is {head_block.name.lower()} at head height.",
+            f"Beneath you lies {below_block.name.lower()}.",
+        ]
+        return " \n".join(descriptions)
+
+    def inventory_summary(self) -> str:
+        if not self.inventory:
+            return "Your inventory is empty."
+        parts = [f"{count} x {blocks.BLOCKS[item].name}" for item, count in sorted(self.inventory.items())]
+        return "You carry: " + ", ".join(parts)

--- a/minecraft/world.py
+++ b/minecraft/world.py
@@ -1,0 +1,200 @@
+"""Procedural world generation and manipulation helpers."""
+from __future__ import annotations
+
+import math
+import random
+from dataclasses import dataclass
+from typing import Dict, Iterable, Iterator, Optional, Tuple
+
+from .blocks import BLOCKS, Block
+
+Coordinate = Tuple[int, int, int]
+
+
+@dataclass(frozen=True)
+class Bounds:
+    width: int
+    depth: int
+    height: int
+
+    def contains(self, position: Coordinate) -> bool:
+        x, y, z = position
+        return 0 <= x < self.width and 0 <= y < self.height and 0 <= z < self.depth
+
+
+class World:
+    """A small procedurally generated voxel world."""
+
+    def __init__(
+        self,
+        width: int = 32,
+        depth: int = 32,
+        height: int = 32,
+        *,
+        seed: Optional[int] = None,
+    ) -> None:
+        if width <= 0 or depth <= 0 or height <= 4:
+            raise ValueError("World dimensions must be positive with height > 4")
+        self.bounds = Bounds(width, depth, height)
+        self.seed = seed if seed is not None else random.randint(0, 2**31 - 1)
+        self.random = random.Random(self.seed)
+        self.sea_level = height // 3 + 2
+        self._blocks: Dict[Coordinate, Block] = {}
+        self._generate_world()
+
+    # ------------------------------------------------------------------
+    # Generation helpers
+
+    def _generate_world(self) -> None:
+        for x in range(self.bounds.width):
+            for z in range(self.bounds.depth):
+                column_height = self._compute_surface_height(x, z)
+                column_height = max(1, min(self.bounds.height - 2, column_height))
+                for y in range(column_height + 1):
+                    if y == column_height:
+                        block_id = "grass" if column_height >= self.sea_level else "sand"
+                    elif y >= column_height - 3:
+                        block_id = "dirt"
+                    else:
+                        block_id = "stone"
+                    self._blocks[(x, y, z)] = BLOCKS[block_id]
+
+                # Fill the column with water if below the sea level.
+                if column_height < self.sea_level:
+                    for y in range(column_height + 1, self.sea_level + 1):
+                        if y < self.bounds.height:
+                            self._blocks[(x, y, z)] = BLOCKS["water"]
+
+                # Plant the occasional tree.
+                if (
+                    column_height >= self.sea_level
+                    and column_height + 5 < self.bounds.height
+                    and self._tree_rng(x, z) < 0.05
+                ):
+                    self._grow_tree((x, column_height + 1, z))
+
+    def _tree_rng(self, x: int, z: int) -> float:
+        tree_random = random.Random((x * 341873128712 + z * 132897987541 + self.seed) & 0xFFFFFFFF)
+        return tree_random.random()
+
+    def _grow_tree(self, trunk_base: Coordinate) -> None:
+        x, y, z = trunk_base
+        for offset in range(4):
+            self._blocks[(x, y + offset, z)] = BLOCKS["log"]
+        leaf_positions = [
+            (x + dx, y + 3 + dy, z + dz)
+            for dx in range(-2, 3)
+            for dy in range(-1, 2)
+            for dz in range(-2, 3)
+            if abs(dx) + abs(dy) + abs(dz) <= 4
+        ]
+        for pos in leaf_positions:
+            if self.bounds.contains(pos):
+                self._blocks[pos] = BLOCKS["leaves"]
+
+    def _compute_surface_height(self, x: int, z: int) -> int:
+        # Coarse ridges using sine waves.
+        ridge = math.sin((x + self.seed) * 0.25) + math.cos((z - self.seed) * 0.3)
+        # Small local variance using a deterministic RNG per column.
+        column_rng = random.Random((x * 49632) ^ (z * 325176) ^ self.seed)
+        jitter = column_rng.uniform(-1.5, 1.5)
+        height = int(self.sea_level + ridge * 1.5 + jitter)
+        return height
+
+    # ------------------------------------------------------------------
+    # Public API
+
+    def spawn_position(self) -> Coordinate:
+        """Return a solid spawn position close to the center of the map."""
+
+        center_x = self.bounds.width // 2
+        center_z = self.bounds.depth // 2
+        return (center_x, self.column_height(center_x, center_z), center_z)
+
+    def column_height(self, x: int, z: int) -> int:
+        """Return the highest non-air block for the column at ``(x, z)``."""
+
+        for y in range(self.bounds.height - 1, -1, -1):
+            block = self._blocks.get((x, y, z))
+            if block and block.id != "air" and block.id != "water":
+                return y
+        return 0
+
+    def get_block(self, position: Coordinate) -> Block:
+        """Return the block located at ``position``.
+
+        Positions outside the world bounds are treated as stone to avoid
+        players walking outside the world.
+        """
+
+        if not self.bounds.contains(position):
+            return BLOCKS["stone"]
+        return self._blocks.get(position, BLOCKS["air"])
+
+    def set_block(self, position: Coordinate, block_id: str) -> bool:
+        """Place ``block_id`` at ``position`` if inside bounds.
+
+        Returns ``True`` if the block was placed.
+        """
+
+        if not self.bounds.contains(position):
+            return False
+        self._blocks[position] = BLOCKS[block_id]
+        return True
+
+    def remove_block(self, position: Coordinate) -> Optional[Block]:
+        """Remove the block at ``position`` and return it."""
+
+        if not self.bounds.contains(position):
+            return None
+        return self._blocks.pop(position, None)
+
+    def top_view(self, center: Coordinate, radius: int = 6) -> str:
+        """Return an ASCII map centered around ``center``."""
+
+        cx, _, cz = center
+        lines = []
+        for dz in range(radius, -radius - 1, -1):
+            row = []
+            for dx in range(-radius, radius + 1):
+                x = cx + dx
+                z = cz + dz
+                if not (0 <= x < self.bounds.width and 0 <= z < self.bounds.depth):
+                    row.append(" ")
+                    continue
+                top_block = self._top_block_symbol(x, z)
+                row.append(top_block)
+            lines.append("".join(row))
+        return "\n".join(lines)
+
+    def _top_block_symbol(self, x: int, z: int) -> str:
+        symbols = {
+            "grass": "▒",
+            "sand": ".",
+            "dirt": "░",
+            "stone": "■",
+            "water": "~",
+            "log": "|",
+            "leaves": "*",
+            "planks": "#",
+        }
+        for y in range(self.bounds.height - 1, -1, -1):
+            block = self._blocks.get((x, y, z))
+            if block and block.id != "air":
+                return symbols.get(block.id, "?")
+        return " "
+
+    def neighbors(self, position: Coordinate) -> Iterator[Coordinate]:
+        x, y, z = position
+        deltas = [(1, 0, 0), (-1, 0, 0), (0, 1, 0), (0, -1, 0), (0, 0, 1), (0, 0, -1)]
+        for dx, dy, dz in deltas:
+            neighbor = (x + dx, y + dy, z + dz)
+            if self.bounds.contains(neighbor):
+                yield neighbor
+
+    def describe(self, position: Coordinate) -> str:
+        block = self.get_block(position)
+        return f"{block.name}: {block.description}"
+
+    def blocks(self) -> Iterable[Tuple[Coordinate, Block]]:
+        return self._blocks.items()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_game.py
+++ b/tests/test_game.py
@@ -1,0 +1,26 @@
+from minecraft.game import Game
+
+
+def test_help_lists_commands():
+    game = Game(width=8, depth=8, height=16, seed=5)
+    text = game.execute("help")
+    assert "look" in text
+    assert "quit" in text
+
+
+def test_move_command_reports_position():
+    game = Game(width=8, depth=8, height=16, seed=6)
+    response = game.execute("move north")
+    assert "You move" in response or "cannot move" in response
+
+
+def test_inventory_command_mentions_planks():
+    game = Game(width=8, depth=8, height=16, seed=10)
+    response = game.execute("inventory")
+    assert "Planks" in response
+
+
+def test_unknown_command():
+    game = Game(width=8, depth=8, height=16, seed=7)
+    response = game.execute("fly")
+    assert "do not understand" in response

--- a/tests/test_player.py
+++ b/tests/test_player.py
@@ -1,0 +1,34 @@
+from minecraft.player import Player
+from minecraft.world import World
+
+
+def make_player(seed: int = 1) -> Player:
+    world = World(width=12, depth=12, height=20, seed=seed)
+    return Player(world)
+
+
+def test_player_starts_with_planks():
+    player = make_player()
+    assert player.inventory["planks"] == 8
+
+
+def test_player_move_horizontal_changes_column():
+    player = make_player()
+    original = player.position
+    moved = player.move("north")
+    assert moved
+    assert player.position != original
+
+
+def test_player_harvest_and_place_cycle():
+    player = make_player()
+    x, y, z = player.position
+    target = (x, y + 1, z)
+    player.world.set_block(target, "log")
+    harvested = player.harvest()
+    assert harvested == "log"
+    assert player.inventory["log"] >= 1
+    placed = player.place("log")
+    assert placed
+    assert player.world.get_block(target).id == "log"
+    assert player.inventory.get("log", 0) == 0

--- a/tests/test_world.py
+++ b/tests/test_world.py
@@ -1,0 +1,36 @@
+from minecraft.world import World
+
+
+def test_world_generation_repeatable():
+    world_a = World(width=16, depth=16, height=24, seed=1234)
+    world_b = World(width=16, depth=16, height=24, seed=1234)
+    assert dict(world_a.blocks()) == dict(world_b.blocks())
+
+
+def test_column_height_non_zero():
+    world = World(width=8, depth=8, height=16, seed=99)
+    for x in range(world.bounds.width):
+        for z in range(world.bounds.depth):
+            assert world.column_height(x, z) >= 0
+
+
+def test_spawn_position_on_surface():
+    world = World(width=10, depth=10, height=20, seed=42)
+    x, y, z = world.spawn_position()
+    assert y == world.column_height(x, z)
+
+
+def test_water_fills_below_sea_level():
+    world = World(width=8, depth=8, height=20, seed=7)
+    found_water = False
+    for x in range(world.bounds.width):
+        for z in range(world.bounds.depth):
+            column_height = world.column_height(x, z)
+            if column_height < world.sea_level:
+                found_water = True
+                for y in range(column_height + 1, min(world.sea_level + 1, world.bounds.height)):
+                    assert world.get_block((x, y, z)).id == "water"
+                break
+        if found_water:
+            break
+    assert found_water, "Expected at least one body of water in the world"


### PR DESCRIPTION
## Summary
- create a miniature Minecraft-inspired sandbox engine with procedural terrain generation and ASCII map rendering
- add player, block, and crafting systems alongside an interactive text adventure command parser
- document gameplay and provide automated tests for world generation, player actions, and command handling

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d5c0c28dd08333a669814549401480